### PR TITLE
feat: seasonal intelligence card (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,217 @@
+# Ridge to Coast
+
+An interactive web map of the **Appalachian watershed corridor** — from the mountain ridge through the Piedmont and the Atlantic Seaboard Fall Line to the Tidewater and the Atlantic Coast. Covers the geological, ecological, and horticultural character of the eastern United States for gardeners, farmers, arborists, and ecological conservation groups.
+
+The map covers the full eastern corridor across **22 states**, from the Blue Ridge highlands and Great Appalachian Valley through the Piedmont, Fall Line, and Atlantic/Gulf Coastal Plains — including **10 ecological regions**, **51 corridor cities**, USDA plant hardiness zones 3b–10a, native plants, and soil profiles from Maine to the Gulf Coast and Great Lakes.
+
+Live at **[ridgetocoast.com](https://ridgetocoast.com)**
+
+---
+
+## What it shows
+
+| Layer / Feature | Description |
+|---|---|
+| **Fall Line** | Approximate path of the geological boundary from Peekskill NY / Hudson Highlands (41.3°N) south through Paterson NJ, Trenton NJ, Baltimore MD, DC, Fredericksburg, Richmond, Raleigh, Columbia SC, Augusta GA, Macon GA to Columbus GA (32.5°N). Click for an ecotone popup with native plants and transitional soil profile. |
+| **New England Fall Zone** | Separate fall zone from Augusta ME south through Manchester NH, Lowell MA, Pawtucket RI to Waterbury CT — the mill-city fall line that powered the Industrial Revolution. |
+| **Coastal Plain (Tidewater)** | East of the mid-Atlantic fall line — flat terrain, sandy/silty sedimentary soils, tidal rivers. Eastern boundary follows the actual US Atlantic coastline (Natural Earth 50m data), including the Outer Banks and Georgia Sea Islands. Click for native plant recommendations and soil profile. |
+| **New England Coastal Lowland** | Glacial outwash and marine sediments SE of the New England fall zone — coastal CT, RI, MA, Long Island, and Cape Cod. Same coastal ecology as the mid-Atlantic Tidewater. |
+| **Piedmont** | West of the fall line — rolling hills, ancient crystalline bedrock, heavy clay soils. Extends from Maryland through the Virginia and Carolina Piedmont to NW Georgia. |
+| **New England Upland** | Glacially scoured crystalline upland NW of the New England fall zone — the equivalent of the Piedmont in CT, MA, NH, VT, and ME. |
+| **Blue Ridge / Appalachian Mountains** | Ancient crystalline highlands from South Mountain PA south through the Shenandoah, Black Mountains NC, and Great Smoky Mountains to NW Georgia. Elevations 1,500–6,600 ft, strongly acidic soils, spruce-fir forests and Southern Appalachian endemics. |
+| **Valley and Ridge / Great Appalachian Valley** | Parallel limestone ridges and fertile valley floors west of the Blue Ridge — the Shenandoah Valley (VA/WV), Cumberland Valley (MD/PA), Tennessee Valley, and Coosa Valley (AL/GA). Rich Alfisols support world-class orchards and grain farms. |
+| **Gulf Coastal Plain** | Southern continuation of the Atlantic Coastal Plain wrapping around the base of the Appalachians — AL/MS fall line, Memphis Embayment, Florida panhandle, and northern Florida peninsula. Tertiary sands and limestone, longleaf pine savannas, cypress swamps. |
+| **Great Lakes Basin** | Wisconsin, Michigan, northern Illinois/Indiana/Ohio, and western New York — the glacially sculpted basin holding 21% of Earth's surface fresh water. Calcareous Alfisols from limestone drift, lake-effect snowbelts, and the oak savanna–boreal forest transition. |
+| **Interior Lowlands / Ohio Valley** | Central/western Ohio, Indiana, Illinois, Kentucky, and central Tennessee — the Ohio–Tennessee–Cumberland river drainages west of the Appalachian Plateau. Some of the deepest, most fertile Alfisols and Mollisols in North America underlie the Bluegrass horse country, Nashville Basin, and Midwest corn belt. |
+| **Major Rivers** | Invisible interactive layer — click any river for a detail page with drainage basin, fall line crossing, and ecological notes. Covers the James, Roanoke, Rappahannock, Potomac, Susquehanna, Delaware, Hudson, Connecticut, Savannah, Altamaha, Chattahoochee, and more. |
+| **Seasonal Intelligence Card** | Live growing season data for any location: NWS frost risk, planting window from USDA hardiness zone calendar, recent iNaturalist plant observations, and nearest USGS river gauge flow. |
+| **Detail pages** | Hash-routed pages (`#detail/region/piedmont`, `#detail/zone/7b`, `#detail/river/james`) with full ecological writeups, native plant lists, soil profiles, and city tables. Shareable URLs. |
+| **Hardiness Zones** | USDA Plant Hardiness Zones 3b–10a across 22 states, lazy-loaded and cached. Semi-transparent overlay so region shading remains visible beneath. Zone-code labels (e.g. `7b`) appear on each polygon at zoom ≥ 9. |
+| **City markers** | 51 corridor cities — fall line, Appalachian, Great Lakes, and Ohio Valley — shown as white circles with a pink border. Click for a popup with: river crossed, founding context (head of navigation history), soil type, and hardiness zone. Hover shows city name tooltip. Toggle in the legend. |
+| **Location search** | Bottom search bar — enter a zip code or city name to fly the map to that location. GPS "locate me" button also supported. Results outside the corridor get a contextual note. |
+
+---
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Map rendering | [Leaflet.js](https://leafletjs.com) 1.9.4 (vendored locally — no CDN) |
+| Base tiles | [CARTO](https://carto.com) `dark_all` (free, no API key) |
+| Fall line / region data | Hand-crafted GeoJSON based on USGS geological surveys |
+| Hardiness zone data | [kgjenkins/ophz](https://github.com/kgjenkins/ophz) (USDA PHZM via PRISM Oregon State), clipped and processed |
+| Geocoding | [Nominatim](https://nominatim.openstreetmap.org) (OpenStreetMap) — free, no API key |
+| Live data | NWS api.weather.gov · iNaturalist API v1 · USGS Water Services |
+| Frontend hosting | [Cloudflare Pages](https://pages.cloudflare.com) — auto-deploys from `app/` on push to `main` |
+| API (P3) | [Cloudflare Workers](https://workers.cloudflare.com) — `api.ridgetocoast.com` (stub, see `workers/`) |
+| Unit tests | Node.js built-in test runner (`node:test`) — zero npm dependencies |
+| E2E tests | [Python Playwright](https://playwright.dev/python/) + pytest |
+| CI | GitHub Actions — unit tests (Node 20 + 22) and E2E (Python 3.12 + Chromium) run in parallel |
+
+---
+
+## Repository layout
+
+```
+ridge-to-coast/
+├── app/                          # Frontend — Leaflet map (deployed to Cloudflare Pages)
+│   ├── index.html                # App shell, CSP meta header, collapsible legend, search bar
+│   ├── style.css                 # Responsive layout, dark theme, mobile-first
+│   ├── map.js                    # Leaflet init, layer logic, legend toggle, search, live data hydration
+│   ├── lib/
+│   │   ├── geo-data.js           # Pure geographic data and helpers (no Leaflet/DOM dependency)
+│   │   ├── leaflet.js            # Vendored Leaflet 1.9.4
+│   │   └── leaflet.css           # Vendored Leaflet CSS
+│   ├── data/
+│   │   ├── hardiness.geojson     # Processed USDA hardiness zones — 22 states, zones 3b–10a
+│   │   └── regions.geojson       # Region polygons (9 features) — async-loaded by map.js
+│   ├── scripts/
+│   │   ├── process-hardiness.js  # CLI: clips raw ophz GeoJSON to corridor bbox, reduces precision
+│   │   ├── extract-coastline.js  # CLI: extracts outer Atlantic coast from Natural Earth 50m data
+│   │   ├── fetch-epa-ecoregions.js  # CLI: fetches EPA Level III ecoregion data via ArcGIS REST API
+│   │   └── extract-regions.js    # CLI: converts EPA Level III ecoregion GeoJSON → data/regions.geojson
+│   ├── docs/
+│   │   └── superpowers/specs/    # Architectural specs (multi-agent workflow artifacts)
+│   └── tests/
+│       ├── geo.test.js           # 327 unit tests across 39 suites (Node built-in runner, no npm needed)
+│       ├── results/              # TAP output from CI runs
+│       └── e2e/                  # Python Playwright E2E tests
+├── workers/                      # Cloudflare Workers — P3 REST API stubs
+│   ├── index.js                  # Router with CORS headers
+│   ├── ecoregion.js              # /v1/ecoregion handler
+│   ├── calendar.js               # /v1/calendar handler
+│   └── plants.js                 # /v1/plants handler
+├── api/
+│   └── openapi.yaml              # OpenAPI 3.1 spec for api.ridgetocoast.com
+├── infra/
+│   └── terraform/                # Cloudflare Pages, DNS, Workers, R2 (IaC)
+├── .github/
+│   └── workflows/
+│       ├── test.yml              # Unit tests — Node 20 and 22, every push and PR
+│       ├── deploy-pages.yml      # Deploy frontend to Cloudflare Pages on push to main
+│       ├── deploy-workers.yml    # Deploy Workers on push to main
+│       └── update-epa-regions.yml  # Daily EPA data fetch (05:00 EST) — auto-commits to main
+├── CLAUDE.md                     # Agent roles, model assignments, project conventions
+└── wrangler.toml                 # Cloudflare Workers deploy config
+```
+
+---
+
+## Running the tests
+
+### Unit tests (Node.js)
+
+No `npm install` needed. Requires Node.js 18+.
+
+```bash
+node --test app/tests/geo.test.js
+```
+
+**327 tests across 39 suites** — see `app/tests/geo.test.js` for full suite listing.
+
+### E2E tests (Python Playwright)
+
+Requires Python 3.8+ and internet access to install the browser once.
+
+```bash
+pip install -r app/tests/e2e/requirements.txt
+playwright install chromium
+python -m http.server 8000 &
+python -m pytest app/tests/e2e/ --base-url http://localhost:8000 -v
+```
+
+---
+
+## Hardiness zone data pipeline
+
+The raw ophz GeoJSON files (~0.1–1.6 MB per state) are not committed. Run the processing script to regenerate `app/data/hardiness.geojson`:
+
+```bash
+BASE=https://raw.githubusercontent.com/kgjenkins/ophz/refs/heads/master/geojson
+
+for STATE in ME NH VT MA RI CT NY NJ DE MD PA WV VA NC SC GA FL AL MS TN KY OH; do
+  curl -sL "$BASE/ophz_${STATE}.geojson" -o /tmp/ophz_${STATE}.geojson
+done
+
+node -e "
+  const fs = require('fs');
+  const states = ['ME','NH','VT','MA','RI','CT','NY','NJ','DE','MD','PA','WV','VA','NC','SC','GA','FL','AL','MS','TN','KY','OH'];
+  const features = states.flatMap(s =>
+    JSON.parse(fs.readFileSync('/tmp/ophz_' + s + '.geojson')).features);
+  fs.writeFileSync('/tmp/ophz_merged.geojson',
+    JSON.stringify({ type:'FeatureCollection', features }));
+  console.log('Total features:', features.length);
+"
+
+node app/scripts/process-hardiness.js /tmp/ophz_merged.geojson app/data/hardiness.geojson
+```
+
+Result: 5125 features, zones 3b–10a, covering the full eastern corridor from Maine to Florida.
+
+**Known data gaps:** Washington DC is not a US state so is excluded from state-level ophz files. DC zone polygons from Maryland border to DC proper may have gaps near Rock Creek Park and the Potomac waterfront.
+
+---
+
+## Region data pipeline
+
+`app/data/regions.geojson` uses EPA Level III Ecoregion boundaries, updated daily by GitHub Actions.
+
+```bash
+node app/scripts/fetch-epa-ecoregions.js
+node app/scripts/extract-regions.js /tmp/us_eco_l3.geojson app/data/regions.geojson
+node --test app/tests/geo.test.js
+```
+
+**Automated:** `.github/workflows/update-epa-regions.yml` runs daily at 05:00 EST and commits any changed `app/data/regions.geojson` directly to `main`. Trigger manually via **Actions → "Update EPA Level III region data" → Run workflow**.
+
+ArcGIS endpoint: `geodata.epa.gov/arcgis/rest/services/ORD/USEPA_Ecoregions_Level_III_and_IV/MapServer/2`
+
+---
+
+## Security
+
+- **Content Security Policy** — enforced via `<meta>` tag in `app/index.html` and Cloudflare Pages `_headers` file. Locks scripts to `'self'`, tiles to CARTO, live data to NWS/iNat/USGS, no eval, no inline scripts.
+- **Vendored Leaflet** — `app/lib/leaflet.js` and `app/lib/leaflet.css` are copied directly from the npm package. No CDN trust required.
+- **No API keys** — CARTO tiles, Nominatim geocoding, NWS, iNaturalist, and USGS Water Services are all free and keyless.
+- **No backend** — fully static frontend; the Workers API (`workers/`) is stub-only pending P3.
+
+---
+
+## Data accuracy
+
+The fall line path is **approximate**, derived from published USGS geological maps. Key verifiable river crossings used as anchors:
+
+| City / Location | River | Coordinates |
+|---|---|---|
+| Peekskill NY | Hudson (Highlands boundary) | 41.290°N, 73.920°W |
+| Paterson NJ | Passaic (Great Falls) | 40.917°N, 74.174°W |
+| Trenton NJ | Delaware | 40.220°N, 74.770°W |
+| Philadelphia PA | Schuylkill / Delaware | 40.000°N, 75.100°W |
+| Great Falls, MD/VA | Potomac | 39.000°N, 77.245°W |
+| Richmond, VA | James (Belle Isle) | 37.527°N, 77.464°W |
+| Raleigh, NC | Neuse (Falls of Neuse) | 35.897°N, 78.648°W |
+| Columbia, SC | Congaree / Saluda | 34.000°N, 81.030°W |
+| Augusta, GA | Savannah | 33.470°N, 82.020°W |
+| Columbus, GA | Chattahoochee | 32.460°N, 84.990°W |
+
+---
+
+## Roadmap
+
+- [x] Fall line corridor — Peekskill NY to Columbus GA
+- [x] Location search (zip code / city) with Nominatim geocoding
+- [x] Hardiness zone overlay with 5-fact popup cards
+- [x] Expand hardiness zone data to 22 states (zones 3b–10a)
+- [x] 51 corridor city markers across all 9 regions
+- [x] Native plant recommendations by ecoregion
+- [x] Soil type detail in region popups
+- [x] Major rivers interactive layer with detail pages
+- [x] Hash-routed detail pages with shareable URLs
+- [x] Great Lakes Basin and Interior Lowlands / Ohio Valley regions
+- [x] Invasive species warnings per region (10 regions, threat badges)
+- [x] Seasonal planting calendar per hardiness zone (14 zones × 12 months)
+- [x] EPA Level III authoritative region polygons with daily update pipeline
+- [x] Move to Cloudflare Pages + ridgetocoast.com domain
+- [x] Phase 2: Live data integrations — NWS frost risk, USGS streamflow, iNaturalist observations, location report pages
+- [ ] Phase 3: Open REST API — `/api/v1/ecoregion`, `/api/v1/calendar`, `/api/v1/plants` via Cloudflare Workers (see `workers/` and `api/openapi.yaml`)
+- [ ] Phase 4: Mobile PWA, watershed education module, custom org layers

--- a/app/README.md
+++ b/app/README.md
@@ -4,7 +4,7 @@ An interactive web map of the **Appalachian watershed corridor** — from the mo
 
 The map covers the full eastern corridor across **22 states**, from the Blue Ridge highlands and Great Appalachian Valley through the Piedmont, Fall Line, and Atlantic/Gulf Coastal Plains — including **10 ecological regions**, **51 corridor cities**, USDA plant hardiness zones 3b–10a, native plants, and soil profiles from Maine to the Gulf Coast and Great Lakes.
 
-Live at **[loobo07.github.io](https://loobo07.github.io)**
+Live at **[ridgetocoast.com](https://ridgetocoast.com)**
 
 ---
 
@@ -52,7 +52,7 @@ Peekskill NY, Paterson NJ, New Brunswick NJ, Philadelphia, DC, Richmond, Raleigh
 | Fall line / region data | Hand-crafted GeoJSON based on USGS geological surveys |
 | Hardiness zone data | [kgjenkins/ophz](https://github.com/kgjenkins/ophz) (USDA PHZM via PRISM Oregon State), clipped and processed |
 | Geocoding | [Nominatim](https://nominatim.openstreetmap.org) (OpenStreetMap) — free, no API key |
-| Hosting | GitHub Pages (static, no backend, no build step) |
+| Hosting | [Cloudflare Pages](https://pages.cloudflare.com) (static, auto-deploys from `app/` on push to `main`) |
 | Unit tests | Node.js built-in test runner (`node:test`) — zero npm dependencies |
 | E2E tests | [Python Playwright](https://playwright.dev/python/) + pytest (85 tests across 5 files) |
 | CI | GitHub Actions — unit tests (Node 20 + 22) and E2E (Python 3.12 + Chromium) run in parallel |
@@ -109,7 +109,7 @@ No `npm install` needed. Requires Node.js 18+.
 node --test tests/geo.test.js
 ```
 
-**308 tests across 37 suites:**
+**327 tests across 39 suites:**
 
 | Suite | What it covers |
 |---|---|
@@ -240,7 +240,7 @@ CEC (North America): `cec.org/north-american-environmental-atlas/terrestrial-eco
 
 ## Security
 
-- **Content Security Policy** — enforced via `<meta>` tag (GitHub Pages cannot set HTTP headers). Locks scripts to `'self'`, tiles to CARTO, geocoding to `nominatim.openstreetmap.org`, no eval, no inline scripts.
+- **Content Security Policy** — enforced via `<meta>` tag in `index.html` and Cloudflare Pages `_headers` file. Locks scripts to `'self'`, tiles to CARTO, live data to NWS/iNat/USGS, no eval, no inline scripts.
 - **Vendored Leaflet** — `lib/leaflet.js` and `lib/leaflet.css` are copied directly from the npm package. No CDN trust required.
 - **No API keys** — CARTO `dark_all` tiles and Nominatim geocoding are free and keyless. All map data is static and same-origin.
 - **No backend** — fully static; no server-side code surface.
@@ -329,6 +329,6 @@ The algorithm collects all coastline points within the corridor bounding box fro
 - [x] Seasonal planting calendar per hardiness zone (14 zones × 12 months)
 - [x] City marker expansion — 51 corridor cities across all 9 regions
 - [ ] EPA Level III authoritative region polygons — pipeline and corrected ArcGIS endpoint in place; trigger via Actions → "Update EPA Level III region data"
-- [ ] Phase 2: Live data integrations — NWS frost advisories, USGS streamflow, iNaturalist observations, watershed delineation, location report pages (see [open issues](../../issues))
+- [x] Phase 2: Live data integrations — NWS frost risk, USGS streamflow, iNaturalist observations, location report pages with Seasonal Intelligence Card
 - [ ] Phase 3: Open REST API — `/api/v1/ecoregion`, `/api/v1/calendar`, `/api/v1/plants` endpoints via Cloudflare Workers (see [open issues](../../issues))
 - [ ] Phase 4: Mobile PWA, watershed education module, custom org layers, sustainable funding

--- a/app/lib/geo-data.js
+++ b/app/lib/geo-data.js
@@ -1919,6 +1919,42 @@ function getCurrentPlantingActivities(zone) {
   };
 }
 
+function makeSeasonalCardShell(zone, region) {
+  var activities = getCurrentPlantingActivities(zone);
+  var plantItems = [].concat(
+    activities.startIndoors.map(function (p) { return p + ' (indoors)'; }),
+    activities.directSow.map(function (p) { return p + ' (sow)'; }),
+    activities.transplant.map(function (p) { return p + ' (transplant)'; })
+  );
+  var plantText = plantItems.length
+    ? plantItems.join(', ')
+    : 'Nothing scheduled for ' + activities.monthName;
+
+  return (
+    '<section class="seasonal-card">' +
+      '<h3 class="seasonal-title">Growing Season \u00b7 Zone ' + zone + '</h3>' +
+      '<div class="seasonal-grid">' +
+        '<div class="seasonal-panel">' +
+          '<span class="seasonal-label">FROST RISK</span>' +
+          '<span id="seasonal-frost" class="seasonal-value seasonal-loading">Loading\u2026</span>' +
+        '</div>' +
+        '<div class="seasonal-panel">' +
+          '<span class="seasonal-label">PLANT NOW</span>' +
+          '<span class="seasonal-value">' + plantText + '</span>' +
+        '</div>' +
+        '<div class="seasonal-panel">' +
+          '<span class="seasonal-label">IN YOUR REGION</span>' +
+          '<span id="seasonal-inat" class="seasonal-value seasonal-loading">Loading\u2026</span>' +
+        '</div>' +
+        '<div class="seasonal-panel">' +
+          '<span class="seasonal-label">RIVERS</span>' +
+          '<span id="seasonal-rivers" class="seasonal-value seasonal-loading">Loading\u2026</span>' +
+        '</div>' +
+      '</div>' +
+    '</section>'
+  );
+}
+
 /**
  * Returns full-page HTML for a location report (search / GPS result).
  * Includes approximate ecoregion, soil, and native plants for the location.
@@ -4249,6 +4285,7 @@ const GeoData = {
   PLANTING_CALENDAR,
   makeCalendarSection,
   getCurrentPlantingActivities,
+  makeSeasonalCardShell,
   makeRegionPopup,
   makeFallLinePopup,
   makeRegionDetailHTML,

--- a/app/lib/geo-data.js
+++ b/app/lib/geo-data.js
@@ -1994,6 +1994,7 @@ function makeLocationReport(lat, lon) {
   var nearestZone = nearest.zone || 'unknown';
   var zoneInfo    = getZoneInfo(nearestZone);
   var zoneSummary = zoneInfo ? zoneInfo.tempRange + '\u2002\u00b7\u2002' + zoneInfo.growingSeason : '';
+  var seasonalShell = makeSeasonalCardShell(nearestZone, region);
 
   var REGION_COLORS = {
     piedmont:         '#c88232',
@@ -2009,6 +2010,7 @@ function makeLocationReport(lat, lon) {
   var accentColor = REGION_COLORS[region] || '#888888';
 
   return (
+    seasonalShell +
     '<article class="detail-page">' +
       '<h2 class="detail-title">Location Report</h2>' +
       '<p class="detail-coords">' +

--- a/app/lib/geo-data.js
+++ b/app/lib/geo-data.js
@@ -1919,8 +1919,9 @@ function getCurrentPlantingActivities(zone) {
   };
 }
 
-function makeSeasonalCardShell(zone, region) {
+function makeSeasonalCardShell(zone, region) { // region forwarded to hydrateSeasonalCard
   var activities = getCurrentPlantingActivities(zone);
+  var safeZone = String(zone).replace(/[<>"'&]/g, '');
   var plantItems = [].concat(
     activities.startIndoors.map(function (p) { return p + ' (indoors)'; }),
     activities.directSow.map(function (p) { return p + ' (sow)'; }),
@@ -1932,7 +1933,7 @@ function makeSeasonalCardShell(zone, region) {
 
   return (
     '<section class="seasonal-card">' +
-      '<h3 class="seasonal-title">Growing Season \u00b7 Zone ' + zone + '</h3>' +
+      '<h3 class="seasonal-title">Growing Season \u00b7 Zone ' + safeZone + '</h3>' +
       '<div class="seasonal-grid">' +
         '<div class="seasonal-panel">' +
           '<span class="seasonal-label">FROST RISK</span>' +

--- a/app/lib/geo-data.js
+++ b/app/lib/geo-data.js
@@ -1902,6 +1902,23 @@ function classifyLocation(lat, lon) {
   return 'piedmont';
 }
 
+function getCurrentPlantingActivities(zone) {
+  var monthKeys = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec'];
+  var monthLabels = ['January','February','March','April','May','June',
+                     'July','August','September','October','November','December'];
+  var idx = new Date().getMonth();
+  var key = monthKeys[idx];
+  var monthName = monthLabels[idx];
+  var entry = PLANTING_CALENDAR[zone] && PLANTING_CALENDAR[zone][key];
+  return {
+    startIndoors: (entry && entry.startIndoors) || [],
+    directSow:    (entry && entry.directSow)    || [],
+    transplant:   (entry && entry.transplant)   || [],
+    harvest:      (entry && entry.harvest)      || [],
+    monthName:    monthName,
+  };
+}
+
 /**
  * Returns full-page HTML for a location report (search / GPS result).
  * Includes approximate ecoregion, soil, and native plants for the location.
@@ -4231,6 +4248,7 @@ const GeoData = {
   makeInvasivesSection,
   PLANTING_CALENDAR,
   makeCalendarSection,
+  getCurrentPlantingActivities,
   makeRegionPopup,
   makeFallLinePopup,
   makeRegionDetailHTML,

--- a/app/map.js
+++ b/app/map.js
@@ -267,6 +267,90 @@ function hydrateZoneFrostAdvisory(lat, lon, token, expectedHash) {
     });
 }
 
+function nearestRiverWithGauge(lat, lon) {
+  var best = null;
+  var bestDist = Infinity;
+  var features = gd.MAJOR_RIVERS_GEOJSON.features;
+  for (var i = 0; i < features.length; i++) {
+    var f = features[i];
+    if (!f.properties.usgsGaugeId) continue;
+    var coords = f.geometry.coordinates;
+    for (var j = 0; j < coords.length; j++) {
+      var d = gd.haversineKm([lon, lat], coords[j]);
+      if (d < bestDist) { bestDist = d; best = f.properties; }
+    }
+  }
+  return best;
+}
+
+async function hydrateSeasonalCard(lat, lon, region, zone, token) {
+  var placeId = gd.REGION_INATURALIST_PLACE_IDS[region];
+  var river = nearestRiverWithGauge(lat, lon);
+
+  var d30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  var d1 = d30.toISOString().slice(0, 10);
+
+  var nwsPromise = fetch('https://api.weather.gov/points/' + lat.toFixed(4) + ',' + lon.toFixed(4))
+    .then(function (r) { if (!r.ok) throw new Error('NWS points failed'); return r.json(); })
+    .then(function (pts) {
+      return fetch(pts.properties.forecastHourly);
+    })
+    .then(function (r) { if (!r.ok) throw new Error('NWS forecast failed'); return r.json(); })
+    .then(function (fc) { return describePlantingWindow(fc.properties.periods); });
+
+  var inatPromise = placeId
+    ? fetch('https://api.inaturalist.org/v1/observations?place_id=' + placeId +
+        '&taxon_id=47126&d1=' + d1 + '&quality_grade=research&per_page=5&order_by=observed_on')
+        .then(function (r) { if (!r.ok) throw new Error('iNat failed'); return r.json(); })
+        .then(function (data) {
+          var species = (data.results || [])
+            .map(function (obs) { return obs.taxon && (obs.taxon.preferred_common_name || obs.taxon.name); })
+            .filter(Boolean);
+          var unique = species.filter(function (s, i) { return species.indexOf(s) === i; });
+          return unique.length
+            ? data.total_results + ' obs \u00b7 ' + unique.slice(0, 3).join(', ')
+            : data.total_results + ' observations';
+        })
+    : Promise.reject(new Error('No place ID for region'));
+
+  var usgsPromise = river
+    ? fetch('https://waterservices.usgs.gov/nwis/iv/?format=json&sites=' + river.usgsGaugeId + '&parameterCd=00060')
+        .then(function (r) { if (!r.ok) throw new Error('USGS failed'); return r.json(); })
+        .then(function (data) {
+          var cfs = extractDischargeCfs(data);
+          if (cfs === null) throw new Error('USGS missing discharge');
+          return river.name + ': ' + Math.round(cfs).toLocaleString('en-US') + ' cfs \u00b7 ' + classifyRiverFlow(cfs);
+        })
+    : Promise.reject(new Error('No river with gauge near location'));
+
+  var results = await Promise.allSettled([nwsPromise, inatPromise, usgsPromise]);
+
+  if (token !== detailRenderToken) return;
+
+  var frostEl   = document.getElementById('seasonal-frost');
+  var inatEl    = document.getElementById('seasonal-inat');
+  var riversEl  = document.getElementById('seasonal-rivers');
+
+  if (frostEl) {
+    frostEl.classList.remove('seasonal-loading');
+    frostEl.textContent = results[0].status === 'fulfilled'
+      ? (results[0].value || 'No frost risk in 7-day forecast')
+      : 'Forecast unavailable';
+  }
+  if (inatEl) {
+    inatEl.classList.remove('seasonal-loading');
+    inatEl.textContent = results[1].status === 'fulfilled'
+      ? results[1].value
+      : 'Observation data unavailable';
+  }
+  if (riversEl) {
+    riversEl.classList.remove('seasonal-loading');
+    riversEl.textContent = results[2].status === 'fulfilled'
+      ? results[2].value
+      : 'Flow data unavailable';
+  }
+}
+
 /**
  * Parse location.hash and render the appropriate view.
  * Hash format: #detail/<type>/<key>
@@ -313,6 +397,15 @@ function navigate(hash) {
     } else {
       clearWatershedHighlight();
     }
+    var locationRegion = !isNaN(lat) && !isNaN(lon) ? gd.classifyLocation(lat, lon) : null;
+    var locationZone = null;
+    if (!isNaN(lat) && !isNaN(lon)) {
+      var nearestForZone = gd.CORRIDOR_CITIES.reduce(function (best, c) {
+        var d = gd.haversineKm([lon, lat], [c.lon, c.lat]);
+        return d < best.d ? { c: c, d: d } : best;
+      }, { c: gd.CORRIDOR_CITIES[0], d: Infinity }).c;
+      locationZone = nearestForZone.zone || '7b';
+    }
   } else if (type === 'garden') {
     clearWatershedHighlight();
     var osmId = decodeURIComponent(parts[2] || '');
@@ -350,6 +443,8 @@ function navigate(hash) {
       populateRiverFlow(parts[2], renderToken);
     } else if (type === 'zone' && zoneRoute && zoneRoute.lat !== null && zoneRoute.lon !== null) {
       hydrateZoneFrostAdvisory(zoneRoute.lat, zoneRoute.lon, renderToken, hash);
+    } else if (type === 'location' && locationRegion && locationZone) {
+      hydrateSeasonalCard(lat, lon, locationRegion, locationZone, renderToken);
     }
   } else {
     clearWatershedHighlight();

--- a/app/style.css
+++ b/app/style.css
@@ -976,3 +976,60 @@ article.detail-page {
 body:has(#detail-view:not([hidden])) {
   overflow: auto;
 }
+
+/* ── Seasonal Intelligence Card ─────────────────────────── */
+.seasonal-card {
+  border-top: 3px solid #4a7c59;
+  margin-bottom: 1.5rem;
+  padding-top: 1rem;
+}
+
+.seasonal-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #b8d4c0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.75rem;
+}
+
+.seasonal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+@media (max-width: 480px) {
+  .seasonal-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.seasonal-panel {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.seasonal-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: #888;
+  text-transform: uppercase;
+}
+
+.seasonal-value {
+  font-size: 0.85rem;
+  color: #ddd;
+  line-height: 1.4;
+}
+
+.seasonal-loading {
+  color: #555;
+  font-style: italic;
+}

--- a/app/tests/geo.test.js
+++ b/app/tests/geo.test.js
@@ -2437,3 +2437,47 @@ describe('getCurrentPlantingActivities', () => {
       `monthName "${result.monthName}" not in month list`);
   });
 });
+
+/* ═══════════════════════════════════════════════════════════════
+   SUITE — makeSeasonalCardShell
+   ═══════════════════════════════════════════════════════════════ */
+
+const { makeSeasonalCardShell } = require('../lib/geo-data.js');
+
+describe('makeSeasonalCardShell', () => {
+  it('contains #seasonal-frost placeholder', () => {
+    const html = makeSeasonalCardShell('7b', 'piedmont');
+    assert.ok(html.includes('id="seasonal-frost"'),
+      'expected id="seasonal-frost" in HTML');
+  });
+
+  it('contains #seasonal-inat placeholder', () => {
+    const html = makeSeasonalCardShell('7b', 'piedmont');
+    assert.ok(html.includes('id="seasonal-inat"'),
+      'expected id="seasonal-inat" in HTML');
+  });
+
+  it('contains #seasonal-rivers placeholder', () => {
+    const html = makeSeasonalCardShell('7b', 'piedmont');
+    assert.ok(html.includes('id="seasonal-rivers"'),
+      'expected id="seasonal-rivers" in HTML');
+  });
+
+  it('planting panel renders sync data (no Loading text)', () => {
+    const html = makeSeasonalCardShell('7b', 'piedmont');
+    // The PLANT NOW panel should not say "Loading"
+    // It uses getCurrentPlantingActivities which is sync
+    const plantPanel = html.match(/PLANT NOW[\s\S]*?<\/div>/);
+    assert.ok(plantPanel, 'PLANT NOW panel not found');
+    assert.ok(!plantPanel[0].includes('Loading'),
+      'PLANT NOW panel should not show Loading state');
+  });
+
+  it('renders safely when PLANTING_CALENDAR has no entry for zone', () => {
+    const html = makeSeasonalCardShell('99z', 'piedmont');
+    assert.ok(typeof html === 'string' && html.length > 0,
+      'should return non-empty HTML string for unknown zone');
+    assert.ok(html.includes('seasonal-card'),
+      'should still render the card container');
+  });
+});

--- a/app/tests/geo.test.js
+++ b/app/tests/geo.test.js
@@ -2405,3 +2405,35 @@ describe('makeCalendarSection()', () => {
     );
   });
 });
+
+/* ═══════════════════════════════════════════════════════════════
+   SUITE — getCurrentPlantingActivities
+   ═══════════════════════════════════════════════════════════════ */
+
+const { getCurrentPlantingActivities } = require('../lib/geo-data.js');
+
+describe('getCurrentPlantingActivities', () => {
+  it('returns arrays for a valid zone', () => {
+    const result = getCurrentPlantingActivities('7b');
+    assert.ok(Array.isArray(result.startIndoors), 'startIndoors should be array');
+    assert.ok(Array.isArray(result.directSow),    'directSow should be array');
+    assert.ok(Array.isArray(result.transplant),   'transplant should be array');
+    assert.ok(Array.isArray(result.harvest),      'harvest should be array');
+  });
+
+  it('returns empty arrays for an unknown zone', () => {
+    const result = getCurrentPlantingActivities('99z');
+    assert.deepEqual(result.startIndoors, []);
+    assert.deepEqual(result.directSow,    []);
+    assert.deepEqual(result.transplant,   []);
+    assert.deepEqual(result.harvest,      []);
+  });
+
+  it('monthName matches a month name string', () => {
+    const result = getCurrentPlantingActivities('7b');
+    const months = ['January','February','March','April','May','June',
+                    'July','August','September','October','November','December'];
+    assert.ok(months.includes(result.monthName),
+      `monthName "${result.monthName}" not in month list`);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `getCurrentPlantingActivities(zone)` — sync read from `PLANTING_CALENDAR` for the current month, returns `{startIndoors, directSow, transplant, harvest, monthName}`
- Adds `makeSeasonalCardShell(zone, region)` — sync HTML shell with `#seasonal-frost`, `#seasonal-inat`, `#seasonal-rivers` placeholders and PLANT NOW panel populated synchronously
- Adds `hydrateSeasonalCard(lat, lon, region, zone, token)` — parallel NWS / iNat / USGS fetches via `Promise.allSettled`, graceful per-panel degradation, render-token guard against stale updates
- Prepends seasonal card to `makeLocationReport` output
- Adds `.seasonal-card` CSS (2×2 grid, responsive 1-col on mobile, dark-theme palette)
- XSS fix: zone string is sanitized before HTML interpolation

## Test plan

- [ ] `node --test app/tests/geo.test.js` — all 327 tests pass (8 new across 2 suites)
- [ ] Search "Richmond VA" → location report shows seasonal card above article
- [ ] `#seasonal-frost`, `#seasonal-inat`, `#seasonal-rivers` hydrate within a few seconds
- [ ] Kill network in DevTools → each panel shows its fallback text independently
- [ ] Mobile viewport (≤480px) → card renders as 1-column

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)