### PR TITLE
fix: rename worker to "ridge-to-coast" in wrangler.toml (#8)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "ridgetocoast-api"
+name = "ridge-to-coast"
 main = "workers/index.js"
 compatibility_date = "2024-01-01"
 account_id = "c378aeb8ad614074b3a5e541a4788993"


### PR DESCRIPTION
## Summary

- Renames `name` in `wrangler.toml` from `"ridgetocoast-api"` to `"ridge-to-coast"` to match Cloudflare Workers Builds expectation

## Root cause

Cloudflare Workers Builds CI was failing with:
\`\`\`
Failed to match Worker name. Your config file is using the Worker name "ridgetocoast-api",
but the CI system expected "ridge-to-coast".
\`\`\`

## Test plan

- [ ] Merge → \`deploy-workers.yml\` runs without name-mismatch warning
- [ ] After also disconnecting Cloudflare Workers Builds (see #9), only GitHub Actions deploys

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)