### PR TITLE
fix: add contents:write permission to update-epa-regions workflow

### DIFF
--- a/.github/workflows/update-epa-regions.yml
+++ b/.github/workflows/update-epa-regions.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
git push was failing with 403 — GITHUB_TOKEN needs explicit write permission to push commits back to main.

Part of #6