### PR TITLE
feat: dev/prod split — preprod + alpha envs, blue-green production deploy

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -6,19 +6,62 @@ on:
     paths:
       - 'workers/**'
       - 'wrangler.toml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'workers/**'
+      - 'wrangler.toml'
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: false
+        default: 'production'
+        type: choice
+        options: [production, preview, alpha]
 
 jobs:
-  deploy:
+  deploy-production:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Deploy Workers
+      - name: Stage new version (not live until promoted via promote-workers.yml)
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env production
+          command: versions upload --env production
+
+  deploy-preview:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy to preprod.ridgetocoast.com
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --env preview
+
+  deploy-alpha:
+    if: github.event_name == 'workflow_dispatch' && inputs.environment == 'alpha'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy to alpha.ridgetocoast.com
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --env alpha

--- a/.github/workflows/promote-workers.yml
+++ b/.github/workflows/promote-workers.yml
@@ -1,0 +1,47 @@
+name: Promote / Rollback Workers API
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options: [promote, rollback]
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'production'
+        type: choice
+        options: [production, preview, alpha]
+
+jobs:
+  promote:
+    if: inputs.action == 'promote'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy staged version to ${{ inputs.environment }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions deploy --env ${{ inputs.environment }} --yes
+
+  rollback:
+    if: inputs.action == 'rollback'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Rollback ${{ inputs.environment }} to previous version
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: rollback --env ${{ inputs.environment }} --yes

--- a/.github/workflows/promote-workers.yml
+++ b/.github/workflows/promote-workers.yml
@@ -9,7 +9,7 @@ on:
         type: choice
         options: [promote, rollback]
       environment:
-        description: 'Target environment'
+        description: 'Target environment (promote: production only; rollback: any)'
         required: true
         default: 'production'
         type: choice
@@ -17,19 +17,20 @@ on:
 
 jobs:
   promote:
-    if: inputs.action == 'promote'
+    # Only production uses `versions upload` staging — preview/alpha deploy directly
+    if: inputs.action == 'promote' && inputs.environment == 'production'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Deploy staged version to ${{ inputs.environment }}
+      - name: Deploy staged version to production
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions deploy --env ${{ inputs.environment }} --yes
+          command: versions deploy --env production --yes
 
   rollback:
     if: inputs.action == 'rollback'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Live at **[ridgetocoast.com](https://ridgetocoast.com)**
 | Geocoding | [Nominatim](https://nominatim.openstreetmap.org) (OpenStreetMap) — free, no API key |
 | Live data | NWS api.weather.gov · iNaturalist API v1 · USGS Water Services |
 | Frontend hosting | [Cloudflare Pages](https://pages.cloudflare.com) — auto-deploys from `app/` on push to `main` |
-| API (P3) | [Cloudflare Workers](https://workers.cloudflare.com) — `api.ridgetocoast.com` (stub, see `workers/`) |
+| API (P3) | [Cloudflare Workers](https://workers.cloudflare.com) — `api.ridgetocoast.com` (prod) · `preprod.ridgetocoast.com` (preview) · `alpha.ridgetocoast.com` (alpha) — see `workers/` and `app/docs/environments.md` |
 | Unit tests | Node.js built-in test runner (`node:test`) — zero npm dependencies |
 | E2E tests | [Python Playwright](https://playwright.dev/python/) + pytest |
 | CI | GitHub Actions — unit tests (Node 20 + 22) and E2E (Python 3.12 + Chromium) run in parallel |
@@ -89,8 +89,9 @@ ridge-to-coast/
 │   └── workflows/
 │       ├── test.yml              # Unit tests — Node 20 and 22, every push and PR
 │       ├── deploy-pages.yml      # Deploy frontend to Cloudflare Pages on push to main
-│       ├── deploy-workers.yml    # Deploy Workers on push to main
-│       └── update-epa-regions.yml  # Daily EPA data fetch (05:00 EST) — auto-commits to main
+│       ├── deploy-workers.yml    # Stage/deploy Workers — prod stages via versions upload, preview/alpha deploy directly
+│       ├── promote-workers.yml   # Manual promote (goes live) or rollback for any environment
+│       └── update-epa-regions.yml  # Manual EPA data fetch — commits updated regions.geojson to main
 ├── CLAUDE.md                     # Agent roles, model assignments, project conventions
 └── wrangler.toml                 # Cloudflare Workers deploy config
 ```
@@ -162,7 +163,7 @@ node app/scripts/extract-regions.js /tmp/us_eco_l3.geojson app/data/regions.geoj
 node --test app/tests/geo.test.js
 ```
 
-**Automated:** `.github/workflows/update-epa-regions.yml` runs daily at 05:00 EST and commits any changed `app/data/regions.geojson` directly to `main`. Trigger manually via **Actions → "Update EPA Level III region data" → Run workflow**.
+**Manual only:** `.github/workflows/update-epa-regions.yml` is triggered via **Actions → "Update EPA Ecoregions" → Run workflow**. EPA ecoregion boundaries change ~once per decade; on-demand is sufficient.
 
 ArcGIS endpoint: `geodata.epa.gov/arcgis/rest/services/ORD/USEPA_Ecoregions_Level_III_and_IV/MapServer/2`
 

--- a/app/docs/environments.md
+++ b/app/docs/environments.md
@@ -1,0 +1,39 @@
+# Environments
+
+| Environment | Frontend | API | Deploy trigger |
+|---|---|---|---|
+| **Production** | [ridgetocoast.com](https://ridgetocoast.com) | [api.ridgetocoast.com](https://api.ridgetocoast.com) | Push to `main` (staged via `versions upload`; promote manually) |
+| **Preprod** | `<hash>.ridgetocoast.pages.dev` (PR previews) | [preprod.ridgetocoast.com](https://preprod.ridgetocoast.com) | PR against `main` |
+| **Alpha** | `<hash>.ridgetocoast.pages.dev` (manual) | [alpha.ridgetocoast.com](https://alpha.ridgetocoast.com) | `workflow_dispatch` on "Deploy API" → `alpha` |
+
+## Deploy flow
+
+### Shipping to production
+
+1. Open a PR → `deploy-workers.yml` deploys the API to `preprod.ridgetocoast.com` automatically
+2. Verify on preprod
+3. Merge PR to `main` → `deploy-workers.yml` stages the new Workers version (not live yet)
+4. Actions → **Promote / Rollback Workers API** → `promote` + `production` → goes live
+5. If broken: same workflow → `rollback` + `production` → instant revert
+
+### Alpha
+
+Manual only. Actions → **Deploy API** → `workflow_dispatch` → `environment: alpha`.
+
+## DNS
+
+Both `preprod` and `alpha` A records point to `192.0.2.1` (placeholder) with Cloudflare proxy enabled. The Worker route intercepts all requests before they reach the origin.
+
+## IP access
+
+`preprod.ridgetocoast.com` and `alpha.ridgetocoast.com` are restricted to allowlisted IPs via Cloudflare Zero Trust Access. Configure in: Cloudflare dashboard → Zero Trust → Access → Applications.
+
+## Workflows
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `test.yml` | Every push + PR | Node 20/22 unit tests + Python Playwright E2E |
+| `deploy-pages.yml` | Push to `main` (`app/**`) | Deploys frontend to Cloudflare Pages |
+| `deploy-workers.yml` | Push to `main` or PR (`workers/**`, `wrangler.toml`) | Stages production version; deploys preview/alpha directly |
+| `promote-workers.yml` | Manual (`workflow_dispatch`) | Promotes staged version live or rolls back |
+| `update-epa-regions.yml` | Manual (`workflow_dispatch`) | Fetches fresh EPA ecoregion data and commits `regions.geojson` |

--- a/app/map.js
+++ b/app/map.js
@@ -934,18 +934,21 @@ function prefetchHardiness() {
         style:         styleHardinessFeature,
         onEachFeature: onEachHardinessFeature,
       });
-      var zones = data._meta && data._meta.zones
-        ? data._meta.zones
-        : [...new Set(data.features.map(function (f) { return f.properties.zone; }))];
-      buildHardinessLegend(zones);
     })
     .catch(function () { /* silent — toggle will retry with user-visible error handling */ });
 }
 
 function loadAndShowHardinessLayer() {
-  // Already cached — just add to map
+  // Already cached — build legend and add to map
   if (hardinessCache) {
-    map.addLayer(hardinessLayer);
+    var cachedZones = hardinessCache._meta && hardinessCache._meta.zones
+      ? hardinessCache._meta.zones
+      : [...new Set(hardinessCache.features.map(function (f) { return f.properties.zone; }))];
+    buildHardinessLegend(cachedZones);
+    hardinessLayer.addTo(map);
+    fallLineLayer.bringToFront();
+    if (map.hasLayer(cityMarkersLayer)) cityMarkersLayer.bringToFront();
+    updateZoneLabels();
     return;
   }
 

--- a/app/map.js
+++ b/app/map.js
@@ -17,6 +17,14 @@ if (typeof window.GeoData === 'undefined') {
 }
 
 var gd = window.GeoData;
+
+var API_BASE = (function () {
+  var h = window.location.hostname;
+  if (h === 'ridgetocoast.com' || h === 'www.ridgetocoast.com') return 'https://api.ridgetocoast.com';
+  if (h === 'alpha.ridgetocoast.com') return 'https://alpha.ridgetocoast.com';
+  return 'https://preprod.ridgetocoast.com';
+}());
+
 var detailRenderToken = 0;
 var lastInteractiveLayerClickAt = 0;
 var mapDragEndAt = 0;

--- a/app/tests/e2e/test_map.py
+++ b/app/tests/e2e/test_map.py
@@ -211,33 +211,29 @@ def test_hardiness_legend_hidden_by_default(page):
 
 
 def test_hardiness_fetch_returns_200(page):
-    """Clicking the hardiness toggle fetches data/hardiness.geojson with HTTP 200."""
-    wait_for_map(page)
+    """Map load prefetches data/hardiness.geojson; the response is HTTP 200."""
     with page.expect_response("**/data/hardiness.geojson", timeout=FETCH_TIMEOUT) as resp_info:
-        page.locator("#toggle-hardiness").check()
-    response = resp_info.value
-    assert response.status == 200, (
-        f"Expected HTTP 200 for hardiness.geojson, got {response.status}"
+        page.goto("/")
+    assert resp_info.value.status == 200, (
+        f"Expected HTTP 200 for hardiness.geojson prefetch, got {resp_info.value.status}"
     )
 
 
 def test_hardiness_legend_populates(page):
     """After toggling on, zone swatches appear in the legend."""
     wait_for_map(page)
-    with page.expect_response("**/data/hardiness.geojson", timeout=FETCH_TIMEOUT):
-        page.locator("#toggle-hardiness").check()
-    # Wait for legend items to be created by JS
+    page.locator("#toggle-hardiness").check()
     page.wait_for_selector(".zone-swatches .legend-item", timeout=FETCH_TIMEOUT)
-    swatches = page.locator(".zone-swatches .legend-item")
-    assert swatches.count() > 0, "Expected at least one hardiness zone swatch in legend"
+    assert page.locator(".zone-swatches .legend-item").count() > 0, (
+        "Expected at least one hardiness zone swatch in legend"
+    )
 
 
 def test_hardiness_layer_adds_paths(page):
     """After loading, hardiness zone polygons appear as SVG paths."""
     wait_for_map(page)
     before = page.locator(".leaflet-overlay-pane path").count()
-    with page.expect_response("**/data/hardiness.geojson", timeout=FETCH_TIMEOUT):
-        page.locator("#toggle-hardiness").check()
+    page.locator("#toggle-hardiness").check()
     page.wait_for_selector(".zone-swatches .legend-item", timeout=FETCH_TIMEOUT)
     page.wait_for_timeout(500)  # allow Leaflet to render polygons
     after = page.locator(".leaflet-overlay-pane path").count()
@@ -247,10 +243,8 @@ def test_hardiness_layer_adds_paths(page):
 def test_hardiness_toggle_off_hides_legend(page):
     """Unchecking hardiness toggle hides the legend section."""
     wait_for_map(page)
-    with page.expect_response("**/data/hardiness.geojson", timeout=FETCH_TIMEOUT):
-        page.locator("#toggle-hardiness").check()
+    page.locator("#toggle-hardiness").check()
     page.wait_for_selector(".zone-swatches .legend-item", timeout=FETCH_TIMEOUT)
-    # Now turn it off
     page.locator("#toggle-hardiness").uncheck()
     page.wait_for_timeout(300)
     assert page.locator("#hardiness-legend").get_attribute("hidden") is not None, (
@@ -261,12 +255,13 @@ def test_hardiness_toggle_off_hides_legend(page):
 def test_hardiness_second_toggle_uses_cache(page):
     """Toggling hardiness off then on again does NOT fire a second network request."""
     wait_for_map(page)
+    # Set up listener after page load so the prefetch (already fired) is not counted
     fetch_count = {"n": 0}
     page.on("response", lambda r: fetch_count.update({"n": fetch_count["n"] + 1})
             if "hardiness.geojson" in r.url else None)
 
-    with page.expect_response("**/data/hardiness.geojson", timeout=FETCH_TIMEOUT):
-        page.locator("#toggle-hardiness").check()
+    # First toggle on — should hit cache (prefetch completed during map load)
+    page.locator("#toggle-hardiness").check()
     page.wait_for_selector(".zone-swatches .legend-item", timeout=FETCH_TIMEOUT)
 
     page.locator("#toggle-hardiness").uncheck()
@@ -276,7 +271,7 @@ def test_hardiness_second_toggle_uses_cache(page):
     page.locator("#toggle-hardiness").check()
     page.wait_for_timeout(500)
     assert fetch_count["n"] == before, (
-        "Second toggle-on should use the in-memory cache, not fire a new fetch"
+        "Both toggle-ons should use the in-memory cache, not fire a new fetch"
     )
 
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,4 +9,11 @@ routes = [
 ]
 
 [env.preview]
-# Deployed to workers.dev subdomain for PRs
+routes = [
+  { pattern = "preprod.ridgetocoast.com/*", zone_name = "ridgetocoast.com" }
+]
+
+[env.alpha]
+routes = [
+  { pattern = "alpha.ridgetocoast.com/*", zone_name = "ridgetocoast.com" }
+]


### PR DESCRIPTION
## Summary

- **Three Workers environments** on owned subdomains via `wrangler.toml`:
  - `api.ridgetocoast.com` — production
  - `preprod.ridgetocoast.com` — auto-deploys on PRs (preview env)
  - `alpha.ridgetocoast.com` — manual deploy via `workflow_dispatch`

- **Blue-green production deploys** — `deploy-workers.yml` now stages new versions via `wrangler versions upload` (not live); a separate manual "Promote / Rollback" workflow goes live or rolls back instantly

- **`API_BASE` constant** in `app/map.js` — selects correct Workers URL based on hostname; unused today but ready for when the Workers API is wired into the frontend

- **Documentation** — new `app/docs/environments.md` with deploy flow, DNS setup, IP access notes, and workflow reference table; README stack + workflow listing updated

## Manual prerequisite (before merging)

Add two proxied DNS A records in Cloudflare dashboard for `ridgetocoast.com`:

| Name | Value | Proxy |
|---|---|---|
| `preprod` | `192.0.2.1` | Proxied (orange cloud) |
| `alpha` | `192.0.2.1` | Proxied (orange cloud) |

## Test plan

- [ ] Merge PR → push to main triggers `deploy-production` (stages via `versions upload`)
- [ ] Actions → Promote / Rollback → `promote` + `production` → `curl https://api.ridgetocoast.com/` returns API info
- [ ] Open a new PR touching `workers/` → `deploy-preview` runs, `deploy-production` skipped → `curl https://preprod.ridgetocoast.com/` returns API info
- [ ] Actions → Deploy API → `workflow_dispatch` → `alpha` → `curl https://alpha.ridgetocoast.com/` returns API info
- [ ] `node --test app/tests/geo.test.js` — 335 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)