### PR TITLE
ci(infra): fix token rotation never firing (drift-gate exit-2 deadlock)

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -58,9 +58,18 @@ jobs:
           terraform_version: "~> 1.11"
       - run: terraform init -input=false
       - name: Drift gate (exit 2 = drift = red)
-        run: terraform plan -detailed-exitcode -no-color -input=false
+        id: drift
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -no-color -input=false
+          plan_exit=$?
+          echo "plan_exit=${plan_exit}" >> "$GITHUB_OUTPUT"
+          # Exit 1 = hard error (bad config, auth failure, etc.) — fail immediately.
+          # Exit 0 = no changes (clean). Exit 2 = changes pending (drift or rotation).
+          # Both 0 and 2 let the job continue so the rotation apply can run.
+          if [ "${plan_exit}" -eq 1 ]; then exit 1; fi
       - name: Targeted rotation apply (inert except at the 90-day boundary)
-        if: success()
+        if: steps.drift.outputs.plan_exit != '1'
         run: |
           terraform apply -auto-approve -no-color -input=false \
             -target=time_rotating.tokens \
@@ -71,6 +80,11 @@ jobs:
             -target=github_actions_environment_secret.preview_cf_token \
             -target=github_actions_environment_secret.alpha_cf_token \
             -target=github_actions_environment_secret.audit_cf_token
+      - name: Fail job when drift was detected
+        if: always() && steps.drift.outputs.plan_exit == '2'
+        run: |
+          echo "::error::Terraform drift detected (plan exit 2). Review the plan output above."
+          exit 1
 
   # Manual: full plan/apply — human-reviewed DNS/TLS/account/import path.
   manual:


### PR DESCRIPTION
## Bug

`terraform plan -detailed-exitcode` exits **2** when changes are pending. GitHub Actions treats any non-zero exit as failure, so the rotation apply step — guarded by `if: success()` — was **skipped every time rotation was actually needed** (90-day boundary). Tokens then expired at day 97 (boundary + 7-day `expires_on` overlap), silently breaking all CI deploys. Outside the boundary, plan exits 0 and the apply runs as a no-op, so the problem only surfaces every 90 days.

## Fix

- Give the drift-gate step an `id: drift`.
- Run plan with `set +e`; capture `$?` into `$GITHUB_OUTPUT` as `plan_exit`.
- The step fails immediately **only on exit 1** (hard Terraform error: bad config, auth failure, etc.).
- Change the rotation apply condition from `success()` → `steps.drift.outputs.plan_exit != '1'`, so it runs on **both exit 0 and exit 2**.
- Add a final `always()` step that fires only when `plan_exit == '2'` and calls `exit 1` — this turns the job red for genuine drift **after** the apply has completed.

## Exit-code trace

| Plan exit | Drift gate step result | Rotation apply runs? | Drift sentinel step | Job result |
|-----------|----------------------|----------------------|---------------------|------------|
| 0 (clean) | success (step exits 0) | yes — `plan_exit != '1'` is true | skipped (`plan_exit != '2'`) | green |
| 1 (hard error) | failure (step exits 1) | no — `plan_exit != '1'` is false; also step failed | skipped (condition false) | red (hard error) |
| 2 (drift or rotation) | success (step exits 0 after capturing exit 2) | yes — `plan_exit != '1'` is true | fires, exits 1, emits `::error::` annotation | red (drift alert) |

Required behavior satisfied: rotation fires at boundary (exit 2 → apply runs); drift turns job red (sentinel step); genuine Terraform errors still fail fast (exit 1 → apply skipped, job red immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)