### PR TITLE
infra(tf): fix audit-readonly token DNS Read scope (zone, not account)

### DIFF
--- a/infra/terraform/tokens.tf
+++ b/infra/terraform/tokens.tf
@@ -10,7 +10,7 @@ locals {
   zone_scope = "com.cloudflare.api.account.zone"
 
   res_account = jsonencode({ "${local.acct_scope}.${var.cloudflare_account_id}" = "*" })
-  res_zone    = jsonencode({ "${local.zone_scope}.${var.cloudflare_zone_id}" = "*" }) # reserved for future zone-scoped permission policies; unused today
+  res_zone    = jsonencode({ "${local.zone_scope}.${var.cloudflare_zone_id}" = "*" }) # zone-scoped resource; used by audit_readonly for DNS Read
 }
 
 data "cloudflare_account_api_token_permission_groups_list" "workers_scripts_write" {
@@ -127,16 +127,23 @@ resource "cloudflare_account_token" "audit_readonly" {
   not_before = local.token_not_before
   expires_on = local.token_expires_on
 
-  policies = [{
-    effect = "allow"
-    permission_groups = [
-      { id = local.pg_dns_read },
-      { id = local.pg_workers_routes_read },
-      { id = local.pg_workers_scripts_read },
-      { id = local.pg_pages_read },
-    ]
-    resources = local.res_account
-  }]
+  policies = [
+    {
+      effect = "allow"
+      permission_groups = [
+        { id = local.pg_workers_routes_read },
+        { id = local.pg_workers_scripts_read },
+        { id = local.pg_pages_read },
+      ]
+      resources = local.res_account
+    },
+    {
+      # DNS Read is zone-category — must be paired with a zone-scoped resource.
+      effect            = "allow"
+      permission_groups = [{ id = local.pg_dns_read }]
+      resources         = local.res_zone
+    },
+  ]
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Summary

- **Bug:** `cloudflare_account_token.audit_readonly` had a single policy listing `pg_dns_read` alongside `pg_workers_routes_read`, `pg_workers_scripts_read`, and `pg_pages_read`, all scoped to `resources = local.res_account`. "DNS Read" is a **zone-category** Cloudflare permission group — pairing it with an account-scoped resource causes Cloudflare to reject the token at `terraform apply`.
- **Fix:** Split `policies` into two entries: (1) account-scoped policy for Workers Routes/Scripts Read and Pages Read, (2) a separate zone-scoped policy for DNS Read using the already-defined `local.res_zone` (`com.cloudflare.api.account.zone.<zone_id>`).
- **Comment updated:** The `res_zone` local had an inline comment saying "unused today" — updated to reflect it is now in active use by `audit_readonly`.

No other tokens (`production_deploy`, `nonprod_deploy`) or data sources were touched.

## Verification

- `terraform fmt && terraform fmt -check` — exit 0 (HCL formatting valid).
- `terraform init -backend=false` — blocked by local Terraform v1.8.3 vs. `required_version >= 1.11`; `validate` could not run. Manual HCL cross-reference review performed instead:
  - `policies` schema confirmed as `Attributes List` (multiple objects allowed) via terraform-provider-cloudflare docs.
  - "DNS Read" scope confirmed as `com.cloudflare.api.account.zone` via Cloudflare API docs (permission groups list endpoint response).
  - Both `local.res_account` and `local.res_zone` are correctly defined `jsonencode(...)` strings in the same file.

## Test plan

- [ ] Run `terraform plan` in the `infra` GitHub Environment after merge to confirm no drift errors.
- [ ] Verify Cloudflare dashboard shows the `audit-readonly` token created successfully with two separate policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)